### PR TITLE
Add styling for cursor on search suggestions

### DIFF
--- a/client/sass/_SearchBar.sass
+++ b/client/sass/_SearchBar.sass
@@ -81,6 +81,7 @@
   background-color: $grey200
   border-radius: 0
   box-shadow: none
+  cursor: pointer
 
   &:first-child
     padding-top: 15px


### PR DESCRIPTION
Prior to this commit, search suggestions triggered the text cursor. This
commit adds the cursor property to search suggestions, so as to trigger
the hand/pointer cursor when hovering over a search suggestion.